### PR TITLE
feat(pairing): wire QR token into PairingService

### DIFF
--- a/Sonar.xcodeproj/project.pbxproj
+++ b/Sonar.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		22941241F1475E0715924783 /* SessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0465EA8D333796B89BEC73E6 /* SessionCoordinator.swift */; };
 		232C990885392AFD2E88E26A /* PermissionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B15898C82CFEB25275371C /* PermissionsManager.swift */; };
 		242391B88E76812F7DF4A9A2 /* VAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490562773FC137386BD73999 /* VAD.swift */; };
+		24F74C6483455BF2DAB55947 /* PairingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B815576B42E78AB3812E5917 /* PairingService.swift */; };
 		268F671BCADDE254BA39D1D2 /* WakeWordDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC0B08E50436501B01CB518 /* WakeWordDetectorTests.swift */; };
 		26B5AA210D50449372F8A7B5 /* LiveKit in Frameworks */ = {isa = PBXBuildFile; productRef = CD72137A877BDAB0A2AA6A03 /* LiveKit */; };
 		283E42D760567123DB0239B7 /* SmartMuteDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F485BF755341E6F0C08CB1F /* SmartMuteDetectorTests.swift */; };
@@ -57,6 +58,7 @@
 		67822B91372101B38A370BB3 /* AirPodsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF43608835E7D99C6B730A43 /* AirPodsController.swift */; };
 		6A66B1651FD904672488E698 /* SonarApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DF1BC0D75E4AB0A7777D84 /* SonarApp.swift */; };
 		6C0B7EE00993E855E3E960BD /* AudioRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B6C7B36F51C4F4C36CF7A /* AudioRouter.swift */; };
+		6F48A9F10BF660DC10101E60 /* PairingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83DEDBD77A96C55D9FCD91E /* PairingServiceTests.swift */; };
 		716212AB43FD194E201B434C /* ProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AA37ED7088D6108CF93914 /* ProfileTests.swift */; };
 		73A889E90771C8B43BBE4E12 /* RoomTokenProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2328FE0FED0DA92C1797F05 /* RoomTokenProvider.swift */; };
 		7688B00F62C5F8475FC346A9 /* DistancePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03F74F74699E5E7CF5DF7AA /* DistancePublisher.swift */; };
@@ -201,6 +203,7 @@
 		AC915C0699321577D76DA12B /* RSSIFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSIFallback.swift; sourceTree = "<group>"; };
 		AE221BB1FB7391C8745FDB3E /* FrameDeduplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameDeduplicator.swift; sourceTree = "<group>"; };
 		AFF7F2B267C3BFDC0833ECEC /* MultipathBonderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipathBonderTests.swift; sourceTree = "<group>"; };
+		B815576B42E78AB3812E5917 /* PairingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingService.swift; sourceTree = "<group>"; };
 		B83CADCFFE5DBA523547DF46 /* SessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionView.swift; sourceTree = "<group>"; };
 		B97A2A95D4BE19F68D6DC7D1 /* SimulatorRelayTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorRelayTransport.swift; sourceTree = "<group>"; };
 		BA71890A5E11D3D250947842 /* BluetoothMeshTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothMeshTransport.swift; sourceTree = "<group>"; };
@@ -218,6 +221,7 @@
 		E1B15898C82CFEB25275371C /* PermissionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsManager.swift; sourceTree = "<group>"; };
 		E55ADCAB3D46E9603D4D2736 /* AIAvatarBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAvatarBadge.swift; sourceTree = "<group>"; };
 		E64B05DA869EBBC166499928 /* FarTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FarTransportTests.swift; sourceTree = "<group>"; };
+		E83DEDBD77A96C55D9FCD91E /* PairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingServiceTests.swift; sourceTree = "<group>"; };
 		E8E74654223E225D63F982F0 /* LocalModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelManager.swift; sourceTree = "<group>"; };
 		EC3E131DAE58F13DFE052BD1 /* ListeningModeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningModeDetector.swift; sourceTree = "<group>"; };
 		ECAE1F338BD522E8698CC6AD /* LatencyBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyBudget.swift; sourceTree = "<group>"; };
@@ -408,6 +412,7 @@
 		A842D6AB144E488355158F52 /* Pairing */ = {
 			isa = PBXGroup;
 			children = (
+				B815576B42E78AB3812E5917 /* PairingService.swift */,
 				79D7CA0F617B8F6C803042F3 /* PairingToken.swift */,
 				9566A616E47346CC16F38E26 /* PairingTokenGenerator.swift */,
 			);
@@ -464,6 +469,7 @@
 				05432E6C166434891FF7C3A5 /* MessageFramingTests.swift */,
 				AFF7F2B267C3BFDC0833ECEC /* MultipathBonderTests.swift */,
 				94770ADBAEB26B3A2B20EB41 /* OpusCodingTests.swift */,
+				E83DEDBD77A96C55D9FCD91E /* PairingServiceTests.swift */,
 				73EBB32A8DA94ACA1BDC13A0 /* PairingTokenTests.swift */,
 				5CF0BBADC68FD17341C420D2 /* PreCaptureBufferTests.swift */,
 				81CA5F86E4BD82A4577DF771 /* PrivacyHardeningTests.swift */,
@@ -541,7 +547,7 @@
 			path = Power;
 			sourceTree = "<group>";
 		};
-		"TEMP_2CAA5179-F527-426C-A737-149F07958517" /* Resources */ = {
+		"TEMP_F9AE4173-39C4-4862-9BD9-5B5C1248E90C" /* Resources */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -651,6 +657,7 @@
 				201E8670396E279B0D7D8103 /* MessageFramingTests.swift in Sources */,
 				B579B5EE09720D138C3177D2 /* MultipathBonderTests.swift in Sources */,
 				5D59C86C377B4A4A792D157A /* OpusCodingTests.swift in Sources */,
+				6F48A9F10BF660DC10101E60 /* PairingServiceTests.swift in Sources */,
 				AF2259E08E42B1742C5F7F40 /* PairingTokenTests.swift in Sources */,
 				E557F9E3FA826328473A1543 /* PreCaptureBufferTests.swift in Sources */,
 				F95993B8E62DFB7D0B68550F /* PrivacyHardeningTests.swift in Sources */,
@@ -711,6 +718,7 @@
 				DA1E088355ABD9903452B7B3 /* NearTransport.swift in Sources */,
 				02C93A964B6B9AD24BDED7D0 /* OnboardingView.swift in Sources */,
 				02E6B10E18799897CE2B1A33 /* OpusCoder.swift in Sources */,
+				24F74C6483455BF2DAB55947 /* PairingService.swift in Sources */,
 				1043EB628E408A754A19934E /* PairingToken.swift in Sources */,
 				F46201F137F854BC041F0FA9 /* PairingTokenGenerator.swift in Sources */,
 				3E1BE94A50085F15E0F6791A /* PairingView.swift in Sources */,

--- a/sonar/Core/Coordinator/SessionCoordinator.swift
+++ b/sonar/Core/Coordinator/SessionCoordinator.swift
@@ -56,6 +56,9 @@ final class SessionCoordinator: ObservableObject {
     // when no peer-driven (simulator-relay) type is otherwise active.
     private let tailscale         = TailscaleDetector.shared
 
+    // QR pairing — observes AppState.pendingPairing and reacts.
+    private let pairingService    = PairingService()
+
     private var cancellables = Set<AnyCancellable>()
     private var audioTask: Task<Void, Never>?
     private var playbackTimer: Timer?
@@ -199,6 +202,14 @@ final class SessionCoordinator: ObservableObject {
                 .store(in: &cancellables)
         }
         guard !Task.isCancelled else { return }
+
+        // MARK: QR pairing — observe AppState.pendingPairing and translate
+        // a successful scan into peerOnline + a Bonjour-host hint for the
+        // transport layer. (The targeted-invite integration in NearTransport
+        // is a follow-up; for now the hint is a NotificationCenter event.)
+        if let appState {
+            pairingService.bind(appState: appState, near: near)
+        }
 
         // MARK: Wake word → AI agent
         wakeWord.start()

--- a/sonar/Core/Pairing/PairingService.swift
+++ b/sonar/Core/Pairing/PairingService.swift
@@ -1,0 +1,115 @@
+import Combine
+import Foundation
+
+/// Bridges the QR-scan UI to the transport layer. When a `PairingView` writes a
+/// freshly-scanned `PairingToken` into `AppState.pendingPairing`, this service
+/// observes the change and:
+///
+/// 1. Validates the token's TTL (rejects anything older than 5 minutes).
+/// 2. Mirrors `id` / `name` into AppState's peer fields so the UI immediately
+///    reflects "paired" — even before the actual transport handshake completes.
+/// 3. Posts a `Notification.Name("sonar.pairing.bonjourHint")` carrying the
+///    Bonjour hostname so a future `NearTransport` extension can prefer that
+///    host for a targeted invite. The actual transport-layer integration
+///    (e.g. an `MCNearbyServiceBrowser.invitePeer` aimed at the hinted host)
+///    is left as a follow-up — for now we only expose the hint.
+///
+/// MainActor-isolated; the Combine subscription is torn down on `deinit`.
+@MainActor
+final class PairingService {
+    /// Notification name carrying the Bonjour hostname from a freshly-scanned
+    /// token. NearTransport can subscribe to this to prefer the hinted host
+    /// for its next invite. The hostname is delivered via
+    /// `notification.userInfo["host"] as? String`.
+    static let bonjourHintNotification = Notification.Name("sonar.pairing.bonjourHint")
+
+    /// Tokens older than this are rejected. Five minutes covers a reasonable
+    /// "I scanned this code a moment ago" window without leaving a stale QR
+    /// code valid forever.
+    static let tokenTTL: TimeInterval = 5 * 60
+
+    /// Injected so tests can pin it without monkey-patching `Date()`.
+    private let now: () -> Date
+
+    private weak var appState: AppState?
+    private weak var near: NearTransport?
+    private weak var bluetooth: BluetoothMeshTransport?
+    private var cancellable: AnyCancellable?
+
+    init(now: @escaping () -> Date = Date.init) {
+        self.now = now
+    }
+
+    deinit {
+        cancellable?.cancel()
+    }
+
+    /// Bind the service to an `AppState`. The optional transport references are
+    /// stored weakly — kept for the future where targeted invites land — but
+    /// the service is intentionally tolerant of `nil` so tests can call
+    /// `bind(appState:)` with no transports attached.
+    func bind(
+        appState: AppState,
+        near: NearTransport? = nil,
+        bluetooth: BluetoothMeshTransport? = nil
+    ) {
+        self.appState = appState
+        self.near = near
+        self.bluetooth = bluetooth
+
+        cancellable?.cancel()
+        // `@Published` fires its sink in `willSet` — observers see the *new*
+        // value but the property hasn't actually been written yet. Hop to the
+        // next main-queue tick before reacting so any clear we do (rejecting
+        // an expired token by setting `pendingPairing = nil`) lands *after*
+        // the original assignment completes.
+        cancellable = appState.$pendingPairing
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] token in
+                self?.handle(token)
+            }
+    }
+
+    // MARK: - Private
+
+    private func handle(_ token: PairingToken?) {
+        guard let token else { return }
+        guard let appState else { return }
+
+        let tokenDate = Date(timeIntervalSince1970: TimeInterval(token.ts))
+        let age = now().timeIntervalSince(tokenDate)
+        if age > Self.tokenTTL {
+            Log.app.warning("Pairing token expired")
+            appState.pendingPairing = nil
+            return
+        }
+
+        Log.app.info(
+            "PairingService accepted token id=\(token.id, privacy: .public) name=\(token.name, privacy: .public) host=\(token.host, privacy: .public)"
+        )
+
+        // Optimistic UI: surface "paired" immediately. The actual transport
+        // handshake (Multipeer, BLE) lands later via NearTransport / BondedPath
+        // signals which will overwrite peerOnline if the connection drops.
+        appState.peerName = token.name
+        appState.peerID = token.id
+        appState.peerOnline = true
+        appState.peerLastSeen = now()
+
+        // Targeted Bonjour invite hint — for now just a NotificationCenter
+        // event. NearTransport's existing browser invites every peer it sees;
+        // a future change can subscribe here to prefer the hinted host.
+        if !token.bonjour.isEmpty {
+            NotificationCenter.default.post(
+                name: Self.bonjourHintNotification,
+                object: nil,
+                userInfo: [
+                    "host": token.host,
+                    "bonjour": token.bonjour,
+                    "peerID": token.id,
+                ]
+            )
+        }
+    }
+}

--- a/sonarTests/PairingServiceTests.swift
+++ b/sonarTests/PairingServiceTests.swift
@@ -1,0 +1,133 @@
+import Combine
+import XCTest
+@testable import Sonar
+
+@MainActor
+final class PairingServiceTests: XCTestCase {
+
+    // Pinned "now" so TTL behavior is deterministic regardless of when the
+    // test runs.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeService() -> PairingService {
+        PairingService(now: { self.now })
+    }
+
+    private func makeToken(
+        id: String = "peer-A",
+        name: String = "Alex iPhone",
+        host: String = "alex.local",
+        bonjour: String = "_sonar._tcp",
+        ageSeconds: TimeInterval = 0
+    ) -> PairingToken {
+        PairingToken(
+            id: id,
+            name: name,
+            bonjour: bonjour,
+            host: host,
+            ts: Int64(now.timeIntervalSince1970 - ageSeconds)
+        )
+    }
+
+    /// PairingService hops onto `DispatchQueue.main` before reacting (so it can
+    /// safely clear `pendingPairing` after `@Published.willSet` returns). Spin
+    /// the run loop once so the deferred work lands before assertions.
+    private func drainMain() {
+        let exp = expectation(description: "main-tick")
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    // MARK: - Fresh, valid token
+
+    func testFreshTokenSetsPeerOnlineAndName() {
+        let appState = AppState()
+        let service = makeService()
+        service.bind(appState: appState)
+
+        XCTAssertFalse(appState.peerOnline)
+        XCTAssertNil(appState.peerName)
+
+        let token = makeToken(id: "peer-A", name: "Alex iPhone", ageSeconds: 10)
+        appState.pendingPairing = token
+        drainMain()
+
+        XCTAssertTrue(appState.peerOnline)
+        XCTAssertEqual(appState.peerName, "Alex iPhone")
+        XCTAssertEqual(appState.peerID, "peer-A")
+        XCTAssertNotNil(appState.peerLastSeen)
+        XCTAssertEqual(appState.peerLastSeen?.timeIntervalSince1970, now.timeIntervalSince1970)
+    }
+
+    // MARK: - Expired token (>5 min)
+
+    func testExpiredTokenIsRejectedAndPeerOnlineStaysFalse() {
+        let appState = AppState()
+        let service = makeService()
+        service.bind(appState: appState)
+
+        // 6 minutes old → past the 5-minute TTL.
+        let stale = makeToken(ageSeconds: 6 * 60)
+        appState.pendingPairing = stale
+        drainMain()
+
+        XCTAssertFalse(appState.peerOnline)
+        XCTAssertNil(appState.peerName)
+        XCTAssertNil(appState.peerID)
+        XCTAssertNil(appState.pendingPairing, "service should clear an expired token")
+    }
+
+    func testTokenAtTTLBoundaryIsAccepted() {
+        let appState = AppState()
+        let service = makeService()
+        service.bind(appState: appState)
+
+        // Exactly 5 minutes old — boundary is inclusive (`age > TTL` rejects).
+        let onTheDot = makeToken(ageSeconds: 5 * 60)
+        appState.pendingPairing = onTheDot
+        drainMain()
+
+        XCTAssertTrue(appState.peerOnline)
+    }
+
+    // MARK: - Nil pendingPairing must not crash
+
+    func testNilPendingPairingDoesNotCrash() {
+        let appState = AppState()
+        let service = makeService()
+        service.bind(appState: appState)
+
+        // Initial nil from binding (the .removeDuplicates upstream emits the
+        // current value); explicitly assigning nil again must not throw.
+        appState.pendingPairing = nil
+        drainMain()
+        XCTAssertFalse(appState.peerOnline)
+
+        // After a valid token, clearing back to nil also must not crash.
+        appState.pendingPairing = makeToken(ageSeconds: 1)
+        drainMain()
+        XCTAssertTrue(appState.peerOnline)
+
+        appState.pendingPairing = nil
+        drainMain()
+        // peerOnline stays true — disconnect is the transport layer's job, not
+        // the pairing service's. We only verify "no crash".
+        XCTAssertTrue(appState.peerOnline)
+    }
+
+    // MARK: - Bonjour hint notification
+
+    func testBonjourHintNotificationCarriesHost() {
+        let appState = AppState()
+        let service = makeService()
+        service.bind(appState: appState)
+
+        let exp = expectation(forNotification: PairingService.bonjourHintNotification, object: nil) { note in
+            (note.userInfo?["host"] as? String) == "alex.local"
+                && (note.userInfo?["peerID"] as? String) == "peer-A"
+        }
+
+        appState.pendingPairing = makeToken(id: "peer-A", host: "alex.local", ageSeconds: 1)
+        wait(for: [exp], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
Round-2 pairing transport hookup. PairingService observes pendingPairing, validates TTL (5 min), emits Bonjour hint Notification, writes optimistic peer state. 285 tests passing.